### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/nnhackernews.el
+++ b/nnhackernews.el
@@ -6,7 +6,7 @@
 ;; Version: 0.1.0
 ;; Keywords: news
 ;; URL: https://github.com/dickmao/nnhackernews
-;; Package-Requires: ((emacs "25.2") (request "20190819") (dash "20190401") (dash-functional "20180107") (anaphora "20180618"))
+;; Package-Requires: ((emacs "25.2") (request "20190819") (dash "2.18.0") (anaphora "20180618"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -50,7 +50,6 @@
 (require 'subr-x)
 (require 'request)
 (require 'dash)
-(require 'dash-functional)
 (require 'anaphora)
 (require 'url-http)
 


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218